### PR TITLE
ANALYTICS-3835 | LIPS: Provide total events and unread events by event_type

### DIFF
--- a/source/includes/_lips_contact_interactions.md
+++ b/source/includes/_lips_contact_interactions.md
@@ -180,14 +180,18 @@ curl -L -g -X GET 'https://data-connect-lips.ganettdigital.com/contact_interacti
     "page": 1,
     "total_pages": 1,
     "per_page": 25,
-    "total_events": 3,
-    "total_call_events": 3,
-    "total_form_events": 0,
-    "total_chat_events": 0,
-    "total_unread_events": 2,
-    "total_unread_call_events": 2,
-    "total_unread_form_events": 0,
-    "total_unread_chat_events": 0
+    "totals": {
+        "events": 3,
+        "call_events": 3,
+        "form_events": 0,
+        "chat_events": 0,
+    },
+    "unread": {
+       "events": 2,
+       "call_events": 2
+       "form_events": 0
+       "chat_events": 0
+    }
 }
 ```
 

--- a/source/includes/_lips_contact_interactions.md
+++ b/source/includes/_lips_contact_interactions.md
@@ -85,6 +85,20 @@ curl -L -g -X GET 'https://data-connect-lips.ganettdigital.com/contact_interacti
 |call_recording_url| String | yes | Only included when interaction is call|
 |call_duration| Integer | yes | Length of call in seconds -- only included when interaction is call|
 
+**Totals**
+| Field Name | Datatype | Nullable | Description |
+|---|---|---|---|
+|total_events| Integer | no | totals of events|
+|total_call_events| Integer | no | totals of call events|
+|total_form_events| Integer | no | totals of form events|
+|total_chat_events| Integer | no | totals of chat events|
+|total_unread_events| Integer | no | totals of unread events|
+|total_unread_call_events| Integer | no | totals of unread call events|
+|total_unread_form_events| Integer | no | totals of unread form events|
+|total_unread_chat_events| Integer | no | totals of unread chat events|
+
+
+
 #### Example Response
 
 ```javascript
@@ -159,7 +173,15 @@ curl -L -g -X GET 'https://data-connect-lips.ganettdigital.com/contact_interacti
     ],
     "page": 1,
     "total_pages": 1,
-    "per_page": 25
+    "per_page": 25,
+    "total_events": 3,
+    "total_call_events": 3,
+    "total_form_events": 0,
+    "total_chat_events": 0,
+    "total_unread_events": 2,
+    "total_unread_call_events": 2,
+    "total_unread_form_events": 0,
+    "total_unread_chat_events": 0
 }
 ```
 

--- a/source/includes/_lips_contact_interactions.md
+++ b/source/includes/_lips_contact_interactions.md
@@ -86,16 +86,22 @@ curl -L -g -X GET 'https://data-connect-lips.ganettdigital.com/contact_interacti
 |call_duration| Integer | yes | Length of call in seconds -- only included when interaction is call|
 
 **Totals**
+
 | Field Name | Datatype | Nullable | Description |
 |---|---|---|---|
-|total_events| Integer | no | totals of events|
-|total_call_events| Integer | no | totals of call events|
-|total_form_events| Integer | no | totals of form events|
-|total_chat_events| Integer | no | totals of chat events|
-|total_unread_events| Integer | no | totals of unread events|
-|total_unread_call_events| Integer | no | totals of unread call events|
-|total_unread_form_events| Integer | no | totals of unread form events|
-|total_unread_chat_events| Integer | no | totals of unread chat events|
+|events| Integer | no | totals of events|
+|call_events| Integer | no | totals of call events|
+|form_events| Integer | no | totals of form events|
+|chat_events| Integer | no | totals of chat events|
+
+**Unread**
+
+| Field Name | Datatype | Nullable | Description |
+|---|---|---|---|
+|events| Integer | no | totals of unread events|
+|call_events| Integer | no | totals of unread call events|
+|form_events| Integer | no | totals of unread form events|
+|chat_events| Integer | no | totals of unread chat events|
 
 
 


### PR DESCRIPTION
*References*:  [ANALYTICS-3835](https://github.com/GannettDigital/lead-ingestion-publication-service/pull/61)