### PR TITLE
ANALYTICS-4219 | 500_response_when_tag_create

### DIFF
--- a/source/includes/_lips_tags.md
+++ b/source/includes/_lips_tags.md
@@ -13,8 +13,8 @@ Are activities associated with a contact or contact interaction. The tag is a st
 | GET `index` | /contact_interactions/#id/tags |
 | GET `index` | /contacts/#id/tags |
 | POST `create` | /tags |
-| POST `create` | /contact_interactions/#id |
-| POST `create` | /contacts/#id |
+| POST `create` | /contact_interactions/#id/tags |
+| POST `create` | /contacts/#id/tags |
 | PUT `update` | /tags/'tag' |
 | DELETE `destroy` | /tags/'tag' |
 | DELETE `destroy` | /contact_interactions/#id/tags/'tag' |


### PR DESCRIPTION
**References**: [ANALYTICS-4219](https://jira.gannett.com/browse/ANALYTICS-4219)

**Code PR**: https://github.com/GannettDigital/lead-ingestion-publication-service/pull/138

**Description**:
We needed to fix the tags post curl in lips tags docs