### PR TITLE
ANALYTICS-4227-add-unique_houshold-household_frequency

### DIFF
--- a/source/includes/_target_geofence.md
+++ b/source/includes/_target_geofence.md
@@ -72,6 +72,9 @@ https://api.localiqservices.com/client_reports/target_geofence/USA_105569?start_
                 "cpw": 0.7
                 "cpm": 0.8, 
                 "spend": 0.9
+                "unique_households": 300,
+                "household_frequency": 26.6
+
             }
         ],
         "target_geofences": [
@@ -105,12 +108,14 @@ https://api.localiqservices.com/client_reports/target_geofence/USA_105569?start_
 |impressions | Int | Total impressions |
 |ctr | Float | Overall Click-through Rate |
 |walk_ins | Float | Total Walk-ins |
-|addressable_geofences | Int | yes | <b>NOTE: The field is Nullable!</b> Total count of Addressable Geofences |
+|target_geofences | Int | Total count of Target Geofences grouped by plat_zipcode |
+| unique_households | Int | Total count of Unique Households |
+| household_frequency | Float | Impressions divided by Unique Households |
 
 *Target Geofence*
 
 | Field Name | Datatype | Description |
-|---|---|---|---|
+|---|---|---|
 |name | String | Name of Geofence <b>(will be null for addressable campaigns)</b> |
 |publisher_plat_zipcode | String | Zip Code <b>(will be null for regular geofence campaigns)</b> |
 |publisher_plat_city | String | City <b>(will be null for regular geofence campaigns)</b> |

--- a/source/includes/_video_activity.md
+++ b/source/includes/_video_activity.md
@@ -210,7 +210,9 @@ https://api.localiqservices.com/client_reports/video_activity/TEST_1?start_date=
             "pause": 2509,
             "resume": 1327,
             "website_conversions": 2,
-            "walk_ins": 2
+            "walk_ins": 2,
+            "unique_households": 150,
+            "household_frequency": 313.5
         },
         "totals_per_interval": [
             {
@@ -291,6 +293,8 @@ https://api.localiqservices.com/client_reports/video_activity/TEST_1?start_date=
 |resume|Integer|Number of Resumed Video Views|
 |website_conversions|Integer|Number of Website Conversions|
 |walk_ins|Integer|Number of Walk Ins|
+|unique_households|Integer|Number of Unique Households|
+|household_frequency|Float|Impressions divided by Unique Households|
 
 <a name="vaintervals"></a>
 **Intervals Object**


### PR DESCRIPTION
**References**: [ANALYTICS-4227](https://jira.gannett.com/browse/ANALYTICS-4227)

**Code PR**: https://github.com/GannettDigital/reach-analytics-reporting-service/pull/1573

**Description**:
adding some unique_household data to target geofence and video activity