### PR TITLE
ANALYTICS-4255 | include_totals_by_campaign_with_top_search_metrics

### DIFF
--- a/source/includes/_search_campaign_metrics.md
+++ b/source/includes/_search_campaign_metrics.md
@@ -132,7 +132,12 @@ https://api.localiqservices.com/client_reports/search_activity/TEST_1?global_mas
                         "rank_lost_absolute_top_search_impression_share": 1,
                         "budget_lost_absolute_top_search_impression_share": 1
                     }
-                ]
+                ],
+                "search_impression_share": 1,
+                "top_search_impression_share": 1,
+                "absolute_top_search_impression_share": 1,
+                "rank_lost_absolute_top_search_impression_share": 1,
+                "budget_lost_absolute_top_search_impression_share": 1
             },
             {
                 "name": "Search Campaign (Demo)",


### PR DESCRIPTION
**References**: [ANALYTICS-4255](https://jira.gannett.com/browse/ANALYTICS-4255)

**Code PR**: https://github.com/GannettDigital/reach-analytics-reporting-service/pull/1583

**Description**:
Added top search metrics in the campaign totals.