### PR TITLE
ANALYTICS-4338 | update-neighborly-ga-system

### DIFF
--- a/source/includes/_google_analytics.md
+++ b/source/includes/_google_analytics.md
@@ -180,7 +180,7 @@ curl --location --request GET 'https://data-connect-staging.gannettdigital.com/c
   "report_type": "google_analytics",
   "report_date": "2022-04-14",
   "start_date": "2021-03-04",
-  "end_date": "2021-03-04",
+  "end_date": "2021-03-05",
   "global_master_advertiser_id": "TEST_1",
   "view_id": "12345678",
   "view_name": null,
@@ -480,6 +480,10 @@ curl --location --request GET 'https://data-connect-staging.gannettdigital.com/c
           {
             "dimension": "2021-03-04",
             "sessions": "19"
+          },
+          {
+            "dimension": "2021-03-05",
+            "sessions": "0"
           }
         ]
       },

--- a/source/includes/_google_services.md
+++ b/source/includes/_google_services.md
@@ -83,6 +83,9 @@ Use POST with a JSON payload to create/update Google service credentials for a g
 |`web_property_name`|No|Creates/updates value.|
 
 **WARNING:** If a `client_id` value is not included the call will create/updated a default configuration for project_id: `client-center-284215` that can only be used to call: `/client_reporting/google_analytics`. Therefore if you intend the configuration to be used to call another report (Ex. `/client_reporting/google_search_console`) the `client_id` should be treated as a `required` param. When provided `client_id` must match value used to create access_token and refresh_token or attempts to refresh a token will fail.
+
+**Special Case: Neigborly Google Analytics**
+For each Neighborly brand only the last configuration created (by any gmaid within that brand) is used when making a call to `google_analytics`
 #### Example Local Dev Curl:
 
 ```

--- a/source/includes/_neighborly_location_review_details.md
+++ b/source/includes/_neighborly_location_review_details.md
@@ -126,6 +126,8 @@ curl -L -X GET 'https://data-connect-prod.gannettdigital.com/client_reports/neig
 ### POST
 
 Use POST with a JSON payload to create/update Neighborly location for a given advertiser.
+Required params: `location_id`, `gmaid` and `brand_code`.
+brand_code is required by the Google Analytics Report to allow for authentication across every gmaid of a given brand.
 
 #### Examples
 
@@ -135,7 +137,8 @@ curl -L -X POST 'https://data-connect-prod.gannettdigital.com/client_reports/nei
 -H 'Content-Type: application/json' \
 --data-raw '{
     "location_id": 53627,
-    "gmaid": "TEST_10294"
+    "gmaid": "TEST_10294",
+    "brand_code": "GUY"
 }'
 ```
 
@@ -145,6 +148,7 @@ curl -L -X POST 'https://data-connect-prod.gannettdigital.com/client_reports/nei
     "location_id": 53627,
     "maid": 10294,
     "platform_id": 7,
+    "brand_code": "GUY",
     "created_at": "2022-06-08T11:06:42.000Z",
     "updated_at": "2022-06-08T11:38:15.000Z"
 }


### PR DESCRIPTION
**References**: [ANALYTICS-4338](https://jira.gannett.com/browse/ANALYTICS-4338)

**Code PR**: https://github.com/GannettDigital/reach-analytics-reporting-service/pull/1606

**Description**:
Updates to allow Neighborly to share GA credentials across each brand.