### PR TITLE
ANALYTICS-4312 | target-geofence-earliest-date-available

### DIFF
--- a/source/includes/_conversion_zone_geofences.md
+++ b/source/includes/_conversion_zone_geofences.md
@@ -42,6 +42,7 @@ https://api.localiqservices.com/client_reports/conversion_zone_geofence/TEST_1?s
     "api_run_date": "2022-11-19",
     "start_date": "2022-04-01",
     "end_date": "2022-04-30",
+    "earliet_date_availabe": "2022-10-01",
     "time_zone": "America/Los_Angeles",
     "currency": "USD",
     "global_master_advertiser_id": "TEST_1",

--- a/source/includes/_target_geofence.md
+++ b/source/includes/_target_geofence.md
@@ -51,6 +51,7 @@ https://api.localiqservices.com/client_reports/target_geofence/USA_105569?start_
     "api_run_date": "2020-11-19",
     "start_date": "2020-11-01",
     "end_date": "2020-11-30",
+    "earliet_date_availabe": "2020-10-01",
     "time_zone": "America/Los_Angeles",
     "currency": "USD",
     "global_master_advertiser_id": "TEST_1",


### PR DESCRIPTION
**References**: [ANALYTICS-4312](https://jira.gannett.com/browse/ANALYTICS-4312)

**Code PR**: https://github.com/GannettDigital/reach-analytics-reporting-service/pull/1616

**Description**:
adding earliest date available to conversion zone and target geofence apis