### PR TITLE
ANALYTICS-4377 | target-geofence-totals

### DIFF
--- a/source/includes/_target_geofence.md
+++ b/source/includes/_target_geofence.md
@@ -10,7 +10,7 @@ Use GET to retrieve information for target geofences. Data can be returned for a
 
 *Note*: Only geofences that more than 1 impression or more than 0 clicks or weighted_actions are included in this API.
 
-For calculated totals see <a name="target_geofence_totals"></a>
+For calculated totals see [target_geofence_totals](https://github.com/GannettDigital/api-docs/blob/master/source/includes/_target_geofence_totals.md)
 ### Parameters
 
 When using the GET method, the results can be filtered using these parameters:

--- a/source/includes/_target_geofence.md
+++ b/source/includes/_target_geofence.md
@@ -10,6 +10,7 @@ Use GET to retrieve information for target geofences. Data can be returned for a
 
 *Note*: Only geofences that more than 1 impression or more than 0 clicks or weighted_actions are included in this API.
 
+For calculated totals see <a name="target_geofence_totals"></a>
 ### Parameters
 
 When using the GET method, the results can be filtered using these parameters:
@@ -63,21 +64,6 @@ https://api.localiqservices.com/client_reports/target_geofence/USA_105569?start_
     "sort_by": "clicks",
     "sort_dir": "desc",
     "report_data": {
-        "totals": [
-            {
-                "impressions": 7970,
-                "clicks": 56,
-                "walk_ins": 34,
-                "ctr": 0.5,
-                "cpc": 0.6,
-                "cpw": 0.7
-                "cpm": 0.8, 
-                "spend": 0.9
-                "unique_households": 300,
-                "household_frequency": 26.6
-
-            }
-        ],
         "target_geofences": [
             {
                 "name" : "Geofence 1",
@@ -100,19 +86,6 @@ https://api.localiqservices.com/client_reports/target_geofence/USA_105569?start_
     }
 }
 ```
-
-*Totals*
-
-| Field Name | Datatype | Description |
-|---|---|---|
-|clicks | Int | Total clicks |
-|impressions | Int | Total impressions |
-|ctr | Float | Overall Click-through Rate |
-|walk_ins | Float | Total Walk-ins |
-|target_geofences | Int | Total count of Target Geofences grouped by plat_zipcode |
-| unique_households | Int | Total count of Unique Households |
-| household_frequency | Float | Impressions divided by Unique Households |
-
 *Target Geofence*
 
 | Field Name | Datatype | Description |

--- a/source/includes/_target_geofence_totals.md
+++ b/source/includes/_target_geofence_totals.md
@@ -8,7 +8,7 @@
 
 Use GET to retrieve information for target geofences totals. Data can be returned for a GMAID for a specific date range determined by start_date and end_date.  The requirements for these parameters are described below.
 
-For paginated breakdown of data see <a name="target_geofences"></a>
+For paginated breakdown of target geofence data see [target_geofence](https://github.com/GannettDigital/api-docs/blob/master/source/includes/_target_geofence.md)
 
 ### Parameters
 

--- a/source/includes/_target_geofence_totals.md
+++ b/source/includes/_target_geofence_totals.md
@@ -76,6 +76,7 @@ https://api.localiqservices.com/client_reports/target_geofence_totals/USA_105569
 |cpc | Float | Cost Per Click |
 |cpw | Float | Cost Per Walk-in |
 |cpm | Float | Cost Per 1000 Impressions |
+|spend| Float| Spend |
 |walk_ins | Int | Total Walk-ins |
 |target_geofences | Int | Total count of Target Geofences grouped by plat_zipcode |
 | unique_households | Int | Total count of Unique Households |

--- a/source/includes/_target_geofence_totals.md
+++ b/source/includes/_target_geofence_totals.md
@@ -1,0 +1,82 @@
+## Target Geofence Totals
+
+### Resource Overview
+
+| Method | URI Format |
+|---|---|
+| GET | /client_reports/target_geofence_totals/[gmaid]?[query_params] |
+
+Use GET to retrieve information for target geofences totals. Data can be returned for a GMAID for a specific date range determined by start_date and end_date.  The requirements for these parameters are described below.
+
+For paginated breakdown of data see <a name="target_geofences"></a>
+
+### Parameters
+
+When using the GET method, the results can be filtered using these parameters:
+
+| Parameter | Required | Description |
+|---|---|---|
+|`start_date`|Yes|Restricts the results to those occurring on or after this date.|
+|`end_date`|Yes|Restricts the results to those occurring on or before this date.|
+|`global_master_campaign_id[]`| no |Restrict results to one or more specific campaigns|
+|`publisher_plat_zipcode[]`|No|Specifies the zipcode+4 to filter by|
+
+### Response Data Details
+
+> Retrieve data for a specific range of dates
+
+```
+curl -H "Authorization: Bearer OAUTH_ACCESS_TOKEN" \
+https://api.localiqservices.com/client_reports/target_geofence_totals/USA_105569?start_date=2016-12-01&end_date=2016-12-31
+```
+
+> Retrieve data for a specific publisher_plat_zipcode
+
+```
+curl -H "Authorization: Bearer OAUTH_ACCESS_TOKEN" \
+https://api.localiqservices.com/client_reports/target_geofence_totals/USA_105569?start_date=2016-12-01&end_date=2016-12-31&publisher_plat_zipcode[]=5555-0001
+```
+
+> Example Response
+
+```javascript
+{
+    "api_name": "target_geofence_totals",
+    "api_run_date": "2022-11-19",
+    "start_date": "2022-05-01",
+    "end_date": "2022-05-30",
+    "earliet_date_availabe": "2022-04-01",
+    "time_zone": "America/Los_Angeles",
+    "currency": "USD",
+    "global_master_advertiser_id": "TEST_1",
+    "advertiser_name": "Advertiser (Demo)",
+    "report_data": {
+      "impressions": 7970,
+      "clicks": 56,
+      "walk_ins": 34,
+      "ctr": 0.5,
+      "cpc": 0.6,
+      "cpw": 0.7
+      "cpm": 0.8, 
+      "spend": 0.9
+      "unique_households": 300,
+      "household_frequency": 26.6,
+      "target_geofences": 24
+    }
+}
+```
+
+*Totals*
+
+| Field Name | Datatype | Description |
+|---|---|---|
+|clicks | Int | Total clicks |
+|impressions | Int | Total impressions |
+|ctr | Float | Overall Click-through Rate |
+|cpc | Float | Cost Per Click |
+|cpw | Float | Cost Per Walk-in |
+|cpm | Float | Cost Per 1000 Impressions |
+|walk_ins | Int | Total Walk-ins |
+|target_geofences | Int | Total count of Target Geofences grouped by plat_zipcode |
+| unique_households | Int | Total count of Unique Households |
+| household_frequency | Float | Impressions divided by Unique Households |


### PR DESCRIPTION
**References**: [ANALYTICS-4377](https://jira.gannett.com/browse/ANALYTICS-4377)

**Code PR**: https://github.com/GannettDigital/reach-analytics-reporting-service/pull/1628

**Description**:
target_geofence is not performing super great so we are moving the totals to their own API 