### PR TITLE
ANALYTICS-4498 extra_fields type documentation

### DIFF
--- a/source/includes/_contact_interactions.md
+++ b/source/includes/_contact_interactions.md
@@ -357,4 +357,4 @@ Field | Type | Description
 sub_type | String | The subtype of the form.  Valid values are **FormPost** and **FormEmail**.
 full_message | String | The full form message
 subject | String | **The field is nullable** |
-extra_fields | Array of String | **The field is nullable** |
+extra_fields | JSON Object with custom attributes | **The field is nullable** |


### PR DESCRIPTION
**References**: [ANALYTICS-4498](https://jira.gannett.com/browse/ANALYTICS-4498)

**Code PR**: none

**Description**:
A customer pointed out a documentation issue.  This is the correction.