### PR TITLE
ANALYTICS-4524 | migrate-unique-domains

### DIFF
--- a/source/includes/rars_unique_domain.md
+++ b/source/includes/rars_unique_domain.md
@@ -29,18 +29,28 @@ curl --request GET \
 > > Example Response
 
 ```json
-[
-    {
-        "domain": "example.com",
-        "count": 80
-    },
-    {
-        "domain": "admin.example.com",
-        "count": 1
-    },
-    {
-        "domain": "www.example.com",
-        "count": 1281
-    }
-]
+{
+  "api_name": "unique_domain",
+  "api_run_date": "2022-12-12",
+  "start_date": "2022-11-28",
+  "end_date": "2022-12-12",
+  "time_zone": "America/Los_Angeles",
+  "report_data": {
+    "domains": [
+      {
+        "domain": "facebook.com",
+        "count": 97
+      },
+      {
+        "domain": "fifa.com",
+        "count": 61
+      },
+      {
+        "domain": "google.com",
+        "count": 57
+      }
+    ]
+  },
+  "global_master_advertiser_id": "TEST_1"
+}
 ```

--- a/source/includes/rars_unique_domain.md
+++ b/source/includes/rars_unique_domain.md
@@ -6,7 +6,7 @@ Returns a list of unique domains that are being tracked for a given advertiser i
 
 | Method | URI Format |
 |---|---|
-| GET | /client_reports/unique-domain/[gmaid] |
+| GET | /client_reports/unique_domain/[gmaid] |
 
 
 ### Response Body
@@ -21,7 +21,7 @@ count | Integer | no | The total visit counts to the specified domain in the las
 
 ```
 curl --request GET \
-  --url 'https://api.localiqservices.com/client_reports/unique-domain/TEST_1' \
+  --url 'https://api.localiqservices.com/client_reports/unique_domain/TEST_1' \
   --header 'Accept: application/json' \
   --header 'Authorization: Bearer OAUTH_ACCESS_TOKEN'
 ```

--- a/source/includes/rars_unique_domain.md
+++ b/source/includes/rars_unique_domain.md
@@ -1,0 +1,46 @@
+## Unique Domain
+
+Returns a list of unique domains that are being tracked for a given advertiser in the past 14 days. The data returned is a list of unique domains along with corresponding visit counts.
+
+### Resource Overview
+
+| Method | URI Format |
+|---|---|
+| GET | /client_reports/unique-domain/[gmaid] |
+
+
+### Response Body
+
+The body of the API response is an array of unique domain objects.
+
+Field Name | Datatype | Nullable | Description
+---------- | -------- | -------- | -----------
+domain | String | no | The unique domain corresponding to the count
+count | Integer | no | The total visit counts to the specified domain in the last 14 days.
+
+
+```
+curl --request GET \
+  --url 'https://api.localiqservices.com/client_reports/unique-domain/TEST_1' \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer OAUTH_ACCESS_TOKEN'
+```
+
+> > Example Response
+
+```json
+[
+    {
+        "domain": "example.com",
+        "count": 80
+    },
+    {
+        "domain": "admin.example.com",
+        "count": 1
+    },
+    {
+        "domain": "www.example.com",
+        "count": 1281
+    }
+]
+```


### PR DESCRIPTION
**References**: [ANALYTICS-4524](https://jira.gannett.com/browse/ANALYTICS-4524)

**Code PR**: https://github.com/GannettDigital/reach-analytics-reporting-service/pull/1722

**Description**:
migrating capture-reporting endpoint to RARS.