### PR TITLE
ANALYTICS-4681 Support interval_size of none

### DIFF
--- a/source/includes/_wpc.md
+++ b/source/includes/_wpc.md
@@ -25,7 +25,7 @@ When using the GET method, the results can be filtered using these parameters:
 |`channel[]`|Restrict results to one or more specific wpc channel. Allowed values are `search`, `display`, `social`, `chat`, `other`, and `shopping`|
 |`campaign_status[]`|Restrict results to all campaigns with given status values.  Allowed values are `running`, `stopped` and `ended`|
 |`campaign_types[]`|Restrict results based on a campaign type|
-|`interval_size`| Use `calendar_month` or `calendar_week` to roll up the data points into calendar intervals (default is 1 day per interval)|
+|`interval_size`| Use `calendar_month` or `calendar_week` to roll up the data points into calendar intervals (default is 1 day per interval) or `none` to remove intervals entirely from the response.|
 
 ### Response Data Details
 


### PR DESCRIPTION
**References**: [ANALYTICS-4681](https://jira.gannett.com/browse/ANALYTICS-4681)
**Code PR**: https://github.com/GannettDigital/reach-analytics-reporting-service/pull/1763
**Regression PR**: https://github.com/GannettDigital/reporting_service_qa_automation/pull/327

**Description**:
In the WPC api add a parameter to allow api client to turn intervals on or off.  This was done by adding support for an interval_size of none.