### PR TITLE
ANALYTICS-4780 Rename unique domains route

### DIFF
--- a/source/includes/_unique_domains.md
+++ b/source/includes/_unique_domains.md
@@ -1,4 +1,4 @@
-## Unique Domain
+## Unique Domains
 
 Returns a list of unique domains that are being tracked for a given advertiser in the past 14 days. The data returned is a list of unique domains along with corresponding visit counts.
 
@@ -6,7 +6,7 @@ Returns a list of unique domains that are being tracked for a given advertiser i
 
 | Method | URI Format |
 |---|---|
-| GET | /client_reports/unique_domain/[gmaid] |
+| GET | /client_reports/unique_domains/[gmaid] |
 
 
 ### Response Body
@@ -21,7 +21,7 @@ count | Integer | no | The total visit counts to the specified domain in the las
 
 ```
 curl --request GET \
-  --url 'https://api.localiqservices.com/client_reports/unique_domain/TEST_1' \
+  --url 'https://api.localiqservices.com/client_reports/unique_domains/TEST_1' \
   --header 'Accept: application/json' \
   --header 'Authorization: Bearer OAUTH_ACCESS_TOKEN'
 ```


### PR DESCRIPTION
**References**: [ANALYTICS-4780](https://jira.gannett.com/browse/ANALYTICS-4780)
**Code PR**: https://github.com/GannettDigital/reach-analytics-reporting-service/pull/1773

**Description**:
[In capture reporting we have](https://confluence.gannett.com/display/LIQAP/Unique+Domains)
```
/unique-domains/[query_params]
```
and [in RARS we have](https://github.com/GannettDigital/api-docs/blob/master/source/includes/rars_unique_domain.md)
```
/unique_domain/[gmaid]
```
This should be plural, it returns domains.   RARS routes use underscores and this is now a RARS API.  While we could support the hyphen in the route, we also require a different parameter scheme so this change is acceptable for consistency.

**Testing Instructions**:
```
curl -L 'http://localhost:3001/client_reports/unique_domains/TEST_1' \
-H 'Authorization: reachanalyticsreportingservicetoken'
```