### PR TITLE
ANALYTICS-4774 Add Facebook Purchase conversion metrics

### DIFF
--- a/source/includes/_socialads_campaign_metrics.md
+++ b/source/includes/_socialads_campaign_metrics.md
@@ -844,6 +844,9 @@ https://api.localiqservices.com/client_reports/facebook_campaign/TEST_1?start_da
 |video_p100_watched_actions|Int|No|Total Videos Watched to 100 percent for Interval|
 |offline_conversion_purchases|Int|No|Total Offline Conversion Purchases for Interval|
 |offline_conversion_purchases_value|Int|No|Total Offline Conversion Purchase Value for Interval|
+|omni_purchase_actions|Int|No| Purchases Value for Interval |
+|omni_purchase_purchase_roas|Int|No| Purchase ROAS for Interval |
+|omni_purchase_action_values|Int|No| Purchase Conversion Value for Interval |
 |cpc|Int|No|Total Cost per Click for Interval|
 |cpm|Int|No|Total Cost per Milli for Interval|
 |ctr|Int|No|Total Click Through Rate for Interval|
@@ -877,6 +880,9 @@ https://api.localiqservices.com/client_reports/facebook_campaign/TEST_1?start_da
 |video_p100_watched_actions|Int|No|Total Videos Watched to 100 percent|
 |offline_conversion_purchases|Int|No|Total Offline Conversion Purchases|
 |offline_conversion_purchases_value|Int|No|Total Offline Conversion Purchase Value|
+|omni_purchase_actions|Int|No| Total Purchases Value |
+|omni_purchase_purchase_roas|Int|No| Total Purchase ROAS |
+|omni_purchase_action_values|Int|No| Total Purchase Conversion Value |
 |cpc|Int|No|Total Cost per Click|
 |cpm|Int|No|Total Cost per Milli|
 |ctr|Int|No|Total Click Through Rate|


### PR DESCRIPTION
**References**: [ANALYTICS-4774](https://jira.gannett.com/browse/ANALYTICS-4774)
**Code PR**:  https://github.com/GannettDigital/reach-analytics-reporting-service/pull/1778

**Description**:
Facebook purchase metrics are now being retrieved in Platform.  Need to add metric definitions to include these in our reporting APIs for facebook.

 Add the following metrics to the Facebook Breakdowns (DailySocialDemographicActivity) model


| Name | Field value in Platform | Field in API response |
| --- | --- |--- |
| Purchases | actions.omni_purchase | omni_purchase_actions |
| Purchase ROAS | purchase_roas.omni_purchase | omni_purchase_action_values |
| Purchase Conversion Value | action_values.omni_purchase | omni_purchase_purchase_roas |

**Testing Instructions**:
There is a manual migration for this story:
```
RENAME TABLE `facebook_breakdowns` TO `daily_social_demographic_activities`
ALTER TABLE `daily_social_demographic_activities` RENAME INDEX `facebook_breakdown_unique_idx` TO `daily_social_demographic_activities_unique_idx`;
ALTER TABLE `daily_social_demographic_activities` CHANGE `facebook_metric_type_id` `metric_type_id` int(11) DEFAULT NULL;

RENAME TABLE `facebook_metric_breakdowns` TO `daily_social_demographic_metric`;
```

Run a backfill
```
curl -L -X POST 'http://localhost:3001/client_reports/backfill' \
-H 'Authorization: reachanalyticsreportingservicetoken' \
-H 'Content-Type: application/json' \
--data-raw '{
    "model": "DailySocialDemographicActivity",
    "from_date": "2022-12-01",
    "to_date": "2023-01-25"
}'
```
**Demo Data**
Demo data will be generated as part of the regular process.