### PR TITLE
ANALYTICS-4824 Added support for LSA channel

### DIFF
--- a/source/includes/_xmedia_channel.md
+++ b/source/includes/_xmedia_channel.md
@@ -654,6 +654,22 @@ curl -H "Authorization: Bearer OAUTH_ACCESS_TOKEN" \
                 "cpl": 1.25
             },
             {
+                "channel": "lsa",
+                "impressions": 2917,
+                "clicks": 31,
+                "click_to_calls": 32,
+                "calls": 32,
+                "qualified_web_events": 0,
+                "non_qualified_web_events": 0,
+                "emails": 13,
+                "chats": 13,
+                "leads": 58,
+                "spend": 58.38,
+                "ctr": 1.06,
+                "cpc": 1.88,
+                "cpl": 1.01
+            },
+            {
                 "channel": "chat",
                 "impressions": 217,
                 "clicks": 5,


### PR DESCRIPTION
**References**: [ANALYTICS-4824](https://jira.gannett.com/browse/ANALYTICS-4824)
**Code PR**: https://github.com/GannettDigital/reach-analytics-reporting-service/pull/1791

**Description**:
XMO is adding LSA as part of their bundle offerings and need these campaigns visible in Client Center reporting. Update the **xmo_channels** API to include these campaigns in the channel breakout sections under **cycles** and **totals_by_channel**.