### PR TITLE
ANALYTICS-4807 Email API V2

### DIFF
--- a/source/includes/_email.md
+++ b/source/includes/_email.md
@@ -5,7 +5,7 @@
 | Method | URI Format |
 |---|---|
 | GET | /client_reports/v2/email/[gmaid]/campaigns?[query_params] |
-| GET | /client_reports/v2/email/[gmaid]/campaigns/[global_master_campaign_id] |
+| GET | /client_reports/v2/email/[gmaid]/campaigns/[external_campaign_id] |
 
 This is an Email Metrics API that can be used by customers that have Email campaigns.
 
@@ -34,7 +34,7 @@ https://api.localiqservices.com/client_reports/v2/email/TEST_1/campaigns?start_d
 
 ```
 curl -H "Authorization: Bearer OAUTH_ACCESS_TOKEN" \
-https://api.localiqservices.com/client_reports/v2/email/TEST_1/campaigns/TEST_15231
+https://api.localiqservices.com/client_reports/v2/email/TEST_1/campaigns/10390
 ```
 
 > Example Response Index
@@ -99,21 +99,21 @@ https://api.localiqservices.com/client_reports/v2/email/TEST_1/campaigns/TEST_15
             "goals": [],
             "external_campaigns": [
                 {
-                    "external_campaign_id": 4048365,
-                    "external_campaign_name": "Demo Campaign Name",
+                    "external_campaign_id": 10390,
+                    "external_campaign_name": "Demo Campaign 1",
                     "from_line": "Demo From Line",
                     "subject_line": "Demo Subject",
-                    "broadcast_date": "2023-03-24",
-                    "quantity": 9999,
-                    "opens": 1456,
-                    "opens_pc": 14.56,
-                    "screenshot_url": "https://api.demo.url/screenshot/2.jpg",
-                    "views": 1456,
-                    "views_pc": 14.56,
-                    "clicks": 282,
-                    "clicks_pc": 2.82,
-                    "ctor": 19.37,
-                    "ctvr": 19.37
+                    "broadcast_date": "2023-04-01",
+                    "quantity": 6053,
+                    "opens": 1591,
+                    "opens_pc": 26.28,
+                    "screenshot_url": "http://cdn.screenshot-test.com/394-285-202102058.png",
+                    "views": 1591,
+                    "views_pc": 26.28,
+                    "clicks": 322,
+                    "clicks_pc": 5.32,
+                    "ctor": 2024.0,
+                    "ctvr": 2024.0
                 }
             ]
         }
@@ -121,109 +121,73 @@ https://api.localiqservices.com/client_reports/v2/email/TEST_1/campaigns/TEST_15
 }
 ```
 
-> Example Response for GMCID Show
+> Example Response for Show
 
 ```json
-
-
-
 {
     "api_name": "email",
-    "api_run_date": "2023-04-19",
+    "api_run_date": "2023-04-21",
     "global_master_advertiser_id": "TEST_1",
     "advertiser_name": "Advertiser (Demo)",
-    "campaign": {
-        "global_master_campaign_id": "TEST_15231",
-        "name": "Email Campaign (Demo)",
-        "type": "email",
-        "status": "running",
-        "goals": [],
-        "external_campaigns": [
+    "external_campaign": {
+        "external_campaign_id": 10390,
+        "external_campaign_name": "Demo Campaign 1",
+        "from_line": "Demo From Line",
+        "subject_line": "Demo Subject",
+        "broadcast_date": "2023-04-01",
+        "quantity": 6053,
+        "opens": 1591,
+        "opens_pc": 26.28,
+        "screenshot_url": "http://cdn.screenshot-test.com/394-285-202102058.png",
+        "views": 1591,
+        "views_pc": 26.28,
+        "clicks": 322,
+        "clicks_pc": 5.32,
+        "ctor": 2024.0,
+        "ctvr": 2024.0,
+        "devices": {
+            "desktop": 161,
+            "mobile": 161
+        },
+        "links": [
             {
-                "external_campaign_id": 15231,
-                "external_campaign_name": "Demo Campaign Name",
-                "from_line": "Demo From Line",
-                "subject_line": "Demo Subject",
-                "broadcast_date": "2023-03-19",
-                "quantity": 9999,
-                "opens": 1536,
-                "opens_pc": 15.36,
-                "screenshot_url": "https://api.demo.url/screenshot/1.jpg",
-                "views": 1536,
-                "views_pc": 15.36,
-                "clicks": 213,
-                "clicks_pc": 2.13,
-                "ctor": 13.87,
-                "ctvr": 13.87,
-                "devices": {
-                    "desktop": 527,
-                    "mobile": 254
+                "index": 1,
+                "clicks": 107,
+                "clicks_pc": 5.3,
+                "width": 2490,
+                "height": 377,
+                "position": {
+                    "left": 5485,
+                    "top": 377
                 },
-                "links": [
-
-                    {
-                        "index": 1,
-                        "clicks": 31,
-                        "clicks_pc": 0.11,
-                        "width": 140,
-                        "height": 42,
-                        "position": {
-                            "left": 42,
-                            "top": 23
-                        },
-                        "link_pc": 3.96,
-                        "url": "demo_url.com"
-                    },
-                    {
-                        "index": 2,
-                        "clicks": 53,
-                        "clicks_pc": 0.18,
-                        "width": 0,
-                        "height": 0,
-                        "position": {
-                            "left": 0,
-                            "top": 0
-                        },
-                        "link_pc": 6.78,
-                        "url": "demo_url.com"
-                    }
-                ]
+                "link_pc": 33.23,
+                "url": "demo_url.com"
             },
             {
-                "external_campaign_id": 4048365,
-                "external_campaign_name": "Demo Campaign Name",
-                "from_line": "Demo From Line",
-                "subject_line": "Demo Subject",
-                "broadcast_date": "2023-03-24",
-                "quantity": 9999,
-                "opens": 1456,
-                "opens_pc": 14.56,
-                "screenshot_url": "https://api.demo.url/screenshot/2.jpg",
-                "views": 1456,
-                "views_pc": 14.56,
-                "clicks": 282,
-                "clicks_pc": 2.82,
-                "ctor": 19.37,
-                "ctvr": 19.37,
-                "devices": {
-                    "desktop": 117,
-                    "mobile": 85
+                "index": 2,
+                "clicks": 107,
+                "clicks_pc": 5.3,
+                "width": 2490,
+                "height": 377,
+                "position": {
+                    "left": 5485,
+                    "top": 377
                 },
-                "links": [
-                    {
-                        "index": 1,
-                        "clicks": 4,
-                        "clicks_pc": 0.06,
-                        "width": 140,
-                        "height": 42,
-                        "position": {
-                            "left": 42,
-                            "top": 23
-                        },
-                        "link_pc": 1.98,
-                        "url": "demo_url.com"
-                    }
-                ]
+                "link_pc": 33.23,
+                "url": "demo_url.com"
+            },
+            {
+                "index": 3,
+                "clicks": 107,
+                "clicks_pc": 5.3,
+                "width": 2490,
+                "height": 377,
+                "position": {
+                    "left": 5485,
+                    "top": 377
+                },
+                "link_pc": 33.23,
+                "url": "demo_url.com"
             }
         ]
     }

--- a/source/includes/_email.md
+++ b/source/includes/_email.md
@@ -1,11 +1,11 @@
 ### **Email**
+<a name="email"></a>
 ### Resource Overview
 
 | Method | URI Format |
 |---|---|
-| GET | /client_reports/email/[gmaid]/campaigns?[query_params] |
-| GET | /client_reports/email/[gmaid]/campaigns/[global_master_campaign_id] |
-
+| GET | /client_reports/v2/email/[gmaid]/campaigns?[query_params] |
+| GET | /client_reports/v2/email/[gmaid]/campaigns/[global_master_campaign_id] |
 
 This is an Email Metrics API that can be used by customers that have Email campaigns.
 
@@ -15,12 +15,11 @@ When using the GET method, the results can be filtered using these parameters:
 
 |Parameter|Required|Description|
 |---|---|---|
-|start_date|When GMCID not present|Restricts the results to those occurring on or after this date|
-|end_date|When GMCID not present|Restricts the results to those occurring on or before this date|
-|page|No|Determines the page to return <br>**Default value is 1**|
-|page_size|No|Determines how many campaigns are returned per page <br>**Default value: 25**|
-|sort_by|No|Determines what attribute to sort by. Possible values: broadcast_date, quantity, opens, opens_pc, views, views_pc, clicks, clicks_pc, ctor, or ctvr  <br>**Default value: broadcast_date**|
-|sort_dir|No|Determines what direction to sort results by.  Possible values: asc or desc <br>**Default value: desc**|
+|`start_date`|When GMCID not present|Restricts the results to those occurring on or after this date|
+|`end_date`|When GMCID not present|Restricts the results to those occurring on or before this date|
+|`global_master_campaign_id[]`|No|Restricts results to all campaigns with given master campaign id|
+|`sort_by`|No|Determines what attribute to sort by. Possible values: broadcast_date, quantity, opens, opens_pc, views, views_pc, clicks, clicks_pc, ctor, or ctvr  <br>**Default value: broadcast_date**|
+|`sort_dir`|No|Determines what direction to sort results by.  Possible values: asc or desc <br>**Default value: desc**|
 
 ### Response Data Details
 
@@ -28,14 +27,14 @@ When using the GET method, the results can be filtered using these parameters:
 
 ```
 curl -H "Authorization: Bearer OAUTH_ACCESS_TOKEN" \
-https://api.localiqservices.com/client_reports/email/TEST_1/campaigns?start_date=2020-10-01&end_date=2020-10-10
+https://api.localiqservices.com/client_reports/v2/email/TEST_1/campaigns?start_date=2020-10-01&end_date=2020-10-10
 ```
 
 > Retrieve data for a specific campaign
 
 ```
 curl -H "Authorization: Bearer OAUTH_ACCESS_TOKEN" \
-https://api.localiqservices.com/client_reports/email/TEST_1/campaigns/TEST_15231
+https://api.localiqservices.com/client_reports/v2/email/TEST_1/campaigns/TEST_15231
 ```
 
 > Example Response Index
@@ -43,11 +42,9 @@ https://api.localiqservices.com/client_reports/email/TEST_1/campaigns/TEST_15231
 ```json
 {
     "api_name": "email",
-    "api_run_date": "2020-11-02",
-    "earliest_date_available": "2020-10-15",
-    "start_date": "2020-10-01",
-    "end_date": "2020-10-16",
-    "time_zone": "America/Los_Angeles",
+    "api_run_date": "2023-04-19",
+    "start_date": "2023-03-17",
+    "end_date": "2023-04-17",
     "global_master_advertiser_id": "TEST_1",
     "advertiser_name": "Advertiser (Demo)",
     "campaigns": [
@@ -57,127 +54,178 @@ https://api.localiqservices.com/client_reports/email/TEST_1/campaigns/TEST_15231
             "type": "email",
             "status": "running",
             "goals": [],
-            "external_campaign_id": 15231,
-            "external_campaign_name": "Demo Campaign Name",
-            "broadcast_date": "2020-10-15",
-            "quantity": 2911,
-            "opens": 1150,
-            "opens_pc": 0.0,
-            "screenshot_url": "https://api.demo.url/screenshot/1.jpg",
-            "views": 281,
-            "views_pc": 0.0,
-            "clicks": 570,
-            "clicks_pc": 0.0,
-            "ctor": 0.1843,
-            "ctvr": 0.1843,
-            "from_line": "Demo From Line",
-            "subject_line": "Demo Subject"
+            "external_campaigns": [
+                {
+                    "external_campaign_id": 15231,
+                    "external_campaign_name": "Demo Campaign Name",
+                    "from_line": "Demo From Line",
+                    "subject_line": "Demo Subject",
+                    "broadcast_date": "2023-03-19",
+                    "quantity": 9999,
+                    "opens": 1536,
+                    "opens_pc": 15.36,
+                    "screenshot_url": "https://api.demo.url/screenshot/1.jpg",
+                    "views": 1536,
+                    "views_pc": 15.36,
+                    "clicks": 213,
+                    "clicks_pc": 2.13,
+                    "ctor": 13.87,
+                    "ctvr": 13.87
+                },
+                {
+                    "external_campaign_id": 15232,
+                    "external_campaign_name": "Demo Campaign Name",
+                    "from_line": "Demo From Line",
+                    "subject_line": "Demo Subject",
+                    "broadcast_date": "2023-03-20",
+                    "quantity": 9999,
+                    "opens": 1456,
+                    "opens_pc": 14.56,
+                    "screenshot_url": "https://api.demo.url/screenshot/2.jpg",
+                    "views": 1456,
+                    "views_pc": 14.56,
+                    "clicks": 282,
+                    "clicks_pc": 2.82,
+                    "ctor": 19.37,
+                    "ctvr": 19.37
+                }
+            ]
+        },
+        {
+            "global_master_campaign_id": "TEST_4048365",
+            "name": "Email Campaign (Demo)",
+            "type": "email",
+            "status": "running",
+            "goals": [],
+            "external_campaigns": [
+                {
+                    "external_campaign_id": 4048365,
+                    "external_campaign_name": "Demo Campaign Name",
+                    "from_line": "Demo From Line",
+                    "subject_line": "Demo Subject",
+                    "broadcast_date": "2023-03-24",
+                    "quantity": 9999,
+                    "opens": 1456,
+                    "opens_pc": 14.56,
+                    "screenshot_url": "https://api.demo.url/screenshot/2.jpg",
+                    "views": 1456,
+                    "views_pc": 14.56,
+                    "clicks": 282,
+                    "clicks_pc": 2.82,
+                    "ctor": 19.37,
+                    "ctvr": 19.37
+                }
+            ]
         }
-    ],
-    "page": 1,
-    "page_size": 25,
-    "total_pages": 1
+    ]
 }
 ```
 
 > Example Response for GMCID Show
 
 ```json
+
+
+
 {
     "api_name": "email",
-    "api_run_date": "2020-11-02",
-    "earliest_date_available": "2020-10-15",
-    "start_date": null,
-    "end_date": null,
-    "time_zone": "America/Los_Angeles",
+    "api_run_date": "2023-04-19",
     "global_master_advertiser_id": "TEST_1",
     "advertiser_name": "Advertiser (Demo)",
-    "campaigns": {
+    "campaign": {
         "global_master_campaign_id": "TEST_15231",
         "name": "Email Campaign (Demo)",
         "type": "email",
         "status": "running",
         "goals": [],
-        "external_campaign_id": 15231,
-        "external_campaign_name": "Demo Campaign Name",
-        "broadcast_date": "2020-10-15",
-        "quantity": 2911,
-        "opens": 1150,
-        "opens_pc": 0.0,
-        "views": 281,
-        "views_pc": 0.0,
-        "clicks": 570,
-        "clicks_pc": 0.0,
-        "ctor": 0.1843,
-        "ctvr": 0.1843,
-        "from_line": "Demo From Line",
-        "subject_line": "Demo Subject",
-        "devices": {
-            "desktop": 285,
-            "mobile": 285
-        },
-        "browsers": {
-            "ie": 114,
-            "chrome": 114,
-            "firefox": 114,
-            "safari": 114,
-            "other": 114
-        },
-        "links": [
+        "external_campaigns": [
             {
                 "external_campaign_id": 15231,
-                "campaign_id": 15231,
-                "platform_id": 7,
-                "index": 1,
-                "clicks": 190,
-                "clicks_pc": 0.0,
-                "width": 300,
-                "height": 241,
-                "position": {
-                    "left": 20,
-                    "top": 40
+                "external_campaign_name": "Demo Campaign Name",
+                "from_line": "Demo From Line",
+                "subject_line": "Demo Subject",
+                "broadcast_date": "2023-03-19",
+                "quantity": 9999,
+                "opens": 1536,
+                "opens_pc": 15.36,
+                "screenshot_url": "https://api.demo.url/screenshot/1.jpg",
+                "views": 1536,
+                "views_pc": 15.36,
+                "clicks": 213,
+                "clicks_pc": 2.13,
+                "ctor": 13.87,
+                "ctvr": 13.87,
+                "devices": {
+                    "desktop": 527,
+                    "mobile": 254
                 },
-                "url": "demo_url.com",
-                "created_at": "2020-10-30T18:57:49.000Z",
-                "updated_at": "2020-10-30T18:57:49.000Z"
+                "links": [
+
+                    {
+                        "index": 1,
+                        "clicks": 31,
+                        "clicks_pc": 0.11,
+                        "width": 140,
+                        "height": 42,
+                        "position": {
+                            "left": 42,
+                            "top": 23
+                        },
+                        "link_pc": 3.96,
+                        "url": "demo_url.com"
+                    },
+                    {
+                        "index": 2,
+                        "clicks": 53,
+                        "clicks_pc": 0.18,
+                        "width": 0,
+                        "height": 0,
+                        "position": {
+                            "left": 0,
+                            "top": 0
+                        },
+                        "link_pc": 6.78,
+                        "url": "demo_url.com"
+                    }
+                ]
             },
             {
-                "external_campaign_id": 15231,
-                "campaign_id": 15231,
-                "platform_id": 7,
-                "index": 2,
-                "clicks": 190,
-                "clicks_pc": 0.0,
-                "width": 300,
-                "height": 241,
-                "position": {
-                    "left": 20,
-                    "top": 40
+                "external_campaign_id": 4048365,
+                "external_campaign_name": "Demo Campaign Name",
+                "from_line": "Demo From Line",
+                "subject_line": "Demo Subject",
+                "broadcast_date": "2023-03-24",
+                "quantity": 9999,
+                "opens": 1456,
+                "opens_pc": 14.56,
+                "screenshot_url": "https://api.demo.url/screenshot/2.jpg",
+                "views": 1456,
+                "views_pc": 14.56,
+                "clicks": 282,
+                "clicks_pc": 2.82,
+                "ctor": 19.37,
+                "ctvr": 19.37,
+                "devices": {
+                    "desktop": 117,
+                    "mobile": 85
                 },
-                "url": "demo_url.com",
-                "created_at": "2020-10-30T18:57:49.000Z",
-                "updated_at": "2020-10-30T18:57:49.000Z"
-            },
-            {
-                "external_campaign_id": 15231,
-                "campaign_id": 15231,
-                "platform_id": 7,
-                "index": 3,
-                "clicks": 190,
-                "width": 300,
-                "height": 241,
-                "position": {
-                    "left": 20,
-                    "top": 40
-                },
-                "clicks_pc": 0.0,
-                "url": "demo_url.com",
-                "created_at": "2020-10-30T18:57:49.000Z",
-                "updated_at": "2020-10-30T18:57:49.000Z"
+                "links": [
+                    {
+                        "index": 1,
+                        "clicks": 4,
+                        "clicks_pc": 0.06,
+                        "width": 140,
+                        "height": 42,
+                        "position": {
+                            "left": 42,
+                            "top": 23
+                        },
+                        "link_pc": 1.98,
+                        "url": "demo_url.com"
+                    }
+                ]
             }
-        ],
-        "screenshot_url": "https://api.demo.url/screenshot/1.jpg",
-        "pdf_base64": "base64 pdf"
+        ]
     }
 }
 ```
@@ -219,10 +267,8 @@ https://api.localiqservices.com/client_reports/email/TEST_1/campaigns/TEST_15231
 |from_line|Object|From Line for email|
 |subject_line|Object|Subject line for email|
 |devices|Device[]|[Array of Device](#deviceemail)|
-|browsers|Browser[]|[Array of Browser](#browseremail)|
 |links|Link[]|[Array of Link](#linkemail)|
 |screenshot_url|String|Link to the campaign screenshot url|
-|pdf_base64|String|Base64 encoded pdf of report|
 
 <a name="goalsemail"></a>
 **Goals**
@@ -253,14 +299,3 @@ https://api.localiqservices.com/client_reports/email/TEST_1/campaigns/TEST_15231
 |---|---|---|
 |desktop|Integer|Number of clicks for Desktop users|
 |mobile|Integer|Number of clicks for Mobile users|
-
-<a name="browseremail"></a>
-**Browser**
-
-|Field Name|Datatype|Description|
-|---|---|---|
-|ie|Integer|Number of clicks from Internet Explorer|
-|chrome|Integer|Number of clicks from Chrome|
-|firefox|Integer|Number of clicks from Firefox|
-|safari|Integer|Number of clicks from Safari|
-|other|Integer|Number of clicks from browsers not listed|

--- a/source/includes/_email.md
+++ b/source/includes/_email.md
@@ -149,6 +149,13 @@ https://api.localiqservices.com/client_reports/v2/email/TEST_1/campaigns/10390
             "desktop": 161,
             "mobile": 161
         },
+        "browsers": {
+            "ie": 114,
+            "chrome": 114,
+            "firefox": 114,
+            "safari": 114,
+            "other": 114
+        },
         "links": [
             {
                 "index": 1,
@@ -231,6 +238,7 @@ https://api.localiqservices.com/client_reports/v2/email/TEST_1/campaigns/10390
 |from_line|Object|From Line for email|
 |subject_line|Object|Subject line for email|
 |devices|Device[]|[Array of Device](#deviceemail)|
+|browsers|Browser[]|[Array of Browser](#browseremail)|
 |links|Link[]|[Array of Link](#linkemail)|
 |screenshot_url|String|Link to the campaign screenshot url|
 
@@ -241,6 +249,17 @@ https://api.localiqservices.com/client_reports/v2/email/TEST_1/campaigns/10390
 |---|---|---|
 | goal_type_id | Integer | goal type id |
 | goal_type | String | goal type name |
+
+<a name="browseremail"></a>
+**Browser**
+
+|Field Name|Datatype|Description|
+|---|---|---|
+|ie|Integer|Number of clicks from Microsoft browsers (Includes Internet Explorer, Edge and any future browsers from Microsoft)|
+|chrome|Integer|Number of clicks from Chrome|
+|firefox|Integer|Number of clicks from Firefox|
+|safari|Integer|Number of clicks from Safari|
+|other|Integer|Number of clicks from browsers not listed|
 
 <a name="linkemail"></a>
 **Link**

--- a/source/includes/_email.md
+++ b/source/includes/_email.md
@@ -18,8 +18,8 @@ When using the GET method, the results can be filtered using these parameters:
 |`start_date`|When GMCID not present|Restricts the results to those occurring on or after this date|
 |`end_date`|When GMCID not present|Restricts the results to those occurring on or before this date|
 |`global_master_campaign_id[]`|No|Restricts results to all campaigns with given master campaign id|
-|`sort_by`|No|Determines what attribute to sort by. Possible values: broadcast_date, quantity, opens, opens_pc, views, views_pc, clicks, clicks_pc, ctor, or ctvr  <br>**Default value: broadcast_date**|
-|`sort_dir`|No|Determines what direction to sort results by.  Possible values: asc or desc <br>**Default value: desc**|
+|`order_by`|No|Determines what attribute to order by. Possible values: broadcast_date, quantity, opens, opens_pc, views, views_pc, clicks, clicks_pc, ctor, or ctvr  <br>**Default value: broadcast_date**|
+|`order_dir`|No|Determines what direction to order results by.  Possible values: asc or desc <br>**Default value: desc**|
 
 ### Response Data Details
 

--- a/source/includes/_email_old.md
+++ b/source/includes/_email_old.md
@@ -1,0 +1,270 @@
+### **Email**
+### Resource Overview
+
+<aside class="warning">
+This API will be removed on June 1, 2023.  It has been replaced with the <a href="#email">new email API<a> that supports a one to many relationship between LocalIQ and external email campaigns.
+</aside>
+
+| Method | URI Format |
+|---|---|
+| GET | /client_reports/email/[gmaid]/campaigns?[query_params] |
+| GET | /client_reports/email/[gmaid]/campaigns/[global_master_campaign_id] |
+
+
+This is an Email Metrics API that can be used by customers that have Email campaigns.
+
+### Parameters
+
+When using the GET method, the results can be filtered using these parameters:
+
+|Parameter|Required|Description|
+|---|---|---|
+|start_date|When GMCID not present|Restricts the results to those occurring on or after this date|
+|end_date|When GMCID not present|Restricts the results to those occurring on or before this date|
+|page|No|Determines the page to return <br>**Default value is 1**|
+|page_size|No|Determines how many campaigns are returned per page <br>**Default value: 25**|
+|sort_by|No|Determines what attribute to sort by. Possible values: broadcast_date, quantity, opens, opens_pc, views, views_pc, clicks, clicks_pc, ctor, or ctvr  <br>**Default value: broadcast_date**|
+|sort_dir|No|Determines what direction to sort results by.  Possible values: asc or desc <br>**Default value: desc**|
+
+### Response Data Details
+
+> Retrieve data for a specific range of dates
+
+```
+curl -H "Authorization: Bearer OAUTH_ACCESS_TOKEN" \
+https://api.localiqservices.com/client_reports/email/TEST_1/campaigns?start_date=2020-10-01&end_date=2020-10-10
+```
+
+> Retrieve data for a specific campaign
+
+```
+curl -H "Authorization: Bearer OAUTH_ACCESS_TOKEN" \
+https://api.localiqservices.com/client_reports/email/TEST_1/campaigns/TEST_15231
+```
+
+> Example Response Index
+
+```json
+{
+    "api_name": "email",
+    "api_run_date": "2020-11-02",
+    "earliest_date_available": "2020-10-15",
+    "start_date": "2020-10-01",
+    "end_date": "2020-10-16",
+    "time_zone": "America/Los_Angeles",
+    "global_master_advertiser_id": "TEST_1",
+    "advertiser_name": "Advertiser (Demo)",
+    "campaigns": [
+        {
+            "global_master_campaign_id": "TEST_15231",
+            "name": "Email Campaign (Demo)",
+            "type": "email",
+            "status": "running",
+            "goals": [],
+            "external_campaign_id": 15231,
+            "external_campaign_name": "Demo Campaign Name",
+            "broadcast_date": "2020-10-15",
+            "quantity": 2911,
+            "opens": 1150,
+            "opens_pc": 0.0,
+            "screenshot_url": "https://api.demo.url/screenshot/1.jpg",
+            "views": 281,
+            "views_pc": 0.0,
+            "clicks": 570,
+            "clicks_pc": 0.0,
+            "ctor": 0.1843,
+            "ctvr": 0.1843,
+            "from_line": "Demo From Line",
+            "subject_line": "Demo Subject"
+        }
+    ],
+    "page": 1,
+    "page_size": 25,
+    "total_pages": 1
+}
+```
+
+> Example Response for GMCID Show
+
+```json
+{
+    "api_name": "email",
+    "api_run_date": "2020-11-02",
+    "earliest_date_available": "2020-10-15",
+    "start_date": null,
+    "end_date": null,
+    "time_zone": "America/Los_Angeles",
+    "global_master_advertiser_id": "TEST_1",
+    "advertiser_name": "Advertiser (Demo)",
+    "campaigns": {
+        "global_master_campaign_id": "TEST_15231",
+        "name": "Email Campaign (Demo)",
+        "type": "email",
+        "status": "running",
+        "goals": [],
+        "external_campaign_id": 15231,
+        "external_campaign_name": "Demo Campaign Name",
+        "broadcast_date": "2020-10-15",
+        "quantity": 2911,
+        "opens": 1150,
+        "opens_pc": 0.0,
+        "views": 281,
+        "views_pc": 0.0,
+        "clicks": 570,
+        "clicks_pc": 0.0,
+        "ctor": 0.1843,
+        "ctvr": 0.1843,
+        "from_line": "Demo From Line",
+        "subject_line": "Demo Subject",
+        "devices": {
+            "desktop": 285,
+            "mobile": 285
+        },
+        "browsers": {
+            "ie": 114,
+            "chrome": 114,
+            "firefox": 114,
+            "safari": 114,
+            "other": 114
+        },
+        "links": [
+            {
+                "external_campaign_id": 15231,
+                "campaign_id": 15231,
+                "platform_id": 7,
+                "index": 1,
+                "clicks": 190,
+                "clicks_pc": 0.0,
+                "width": 300,
+                "height": 241,
+                "position": {
+                    "left": 20,
+                    "top": 40
+                },
+                "url": "demo_url.com",
+                "created_at": "2020-10-30T18:57:49.000Z",
+                "updated_at": "2020-10-30T18:57:49.000Z"
+            },
+            {
+                "external_campaign_id": 15231,
+                "campaign_id": 15231,
+                "platform_id": 7,
+                "index": 2,
+                "clicks": 190,
+                "clicks_pc": 0.0,
+                "width": 300,
+                "height": 241,
+                "position": {
+                    "left": 20,
+                    "top": 40
+                },
+                "url": "demo_url.com",
+                "created_at": "2020-10-30T18:57:49.000Z",
+                "updated_at": "2020-10-30T18:57:49.000Z"
+            },
+            {
+                "external_campaign_id": 15231,
+                "campaign_id": 15231,
+                "platform_id": 7,
+                "index": 3,
+                "clicks": 190,
+                "width": 300,
+                "height": 241,
+                "position": {
+                    "left": 20,
+                    "top": 40
+                },
+                "clicks_pc": 0.0,
+                "url": "demo_url.com",
+                "created_at": "2020-10-30T18:57:49.000Z",
+                "updated_at": "2020-10-30T18:57:49.000Z"
+            }
+        ],
+        "screenshot_url": "https://api.demo.url/screenshot/1.jpg",
+        "pdf_base64": "base64 pdf"
+    }
+}
+```
+
+|Field Name|Datatype|Description|
+|---|---|---|
+|api_name|String|Name of the API|
+|api_run_date|String|Date report was run|
+|earliest_date_available|String|How far back data is available|
+|start_date|String|Start Date|
+|end_date|String|End Date|
+|time_zone|String|Time Zone of Data|
+|global_master_advertiser_id|String|Identifier for Advertiser|
+|advertiser_name|String|Name of Advertiser|
+|campaigns|Campaign[]|[Arrays of Campaigns](#campaignsemail)|
+
+<a name="campaignsemail"></a>
+**Campaigns**
+
+|Field Name|Datatype|Description|
+|---|---|---|
+|global_master_campaign_id|String|Unique Campaign Identifier.|
+|name|String|Campaign Name|
+|type|String|Campaign Type|
+|status|String|Campaign Status|
+|goals|Goal[]|[Array of Goals](#goalsemail)|
+|external_campaign_id|String|Email Vendor's Campaign Identifier|
+|external_campaign_name|String|Email Vendor's Campaign Name|
+|broadcast_date|String|Date Email was pushed out|
+|quantity|Int|Number of emails sent|
+|opens|Int|Number of emails opened|
+|opens_pc|Float|Percent of emails opened|
+|views|Int|Number of emails viewed|
+|views_pc|Float|Percent of emails viewed|
+|clicks|Int|Number of emails clicked|
+|clicks_pc|Float|Percent of emails clicked|
+|ctor|Float|Click-through Rate|
+|ctvr|Float|CTVR|
+|from_line|Object|From Line for email|
+|subject_line|Object|Subject line for email|
+|devices|Device[]|[Array of Device](#deviceemail)|
+|browsers|Browser[]|[Array of Browser](#browseremail)|
+|links|Link[]|[Array of Link](#linkemail)|
+|screenshot_url|String|Link to the campaign screenshot url|
+|pdf_base64|String|Base64 encoded pdf of report|
+
+<a name="goalsemail"></a>
+**Goals**
+
+| Field Name | Datatype | Description |
+|---|---|---|
+| goal_type_id | Integer | goal type id |
+| goal_type | String | goal type name |
+
+<a name="linkemail"></a>
+**Link**
+
+|Field Name|Datatype|Description|
+|---|---|---|
+|index|Int|Index of Link|
+|clicks|Int|Number of clicks for Link|
+|clicks_pc|Float|Percent of Link clicks vs quantity|
+|link_pc|Float|Percent of Link clicks vs Total Clicks|
+|width|Int|The width of the Link|
+|height|Int|The height of the Link|
+|position|Int|The position (top and left) of the Link|
+|url|String|URL of Link|
+
+<a name="deviceemail"></a>
+**Device**
+
+|Field Name|Datatype|Description|
+|---|---|---|
+|desktop|Integer|Number of clicks for Desktop users|
+|mobile|Integer|Number of clicks for Mobile users|
+
+<a name="browseremail"></a>
+**Browser**
+
+|Field Name|Datatype|Description|
+|---|---|---|
+|ie|Integer|Number of clicks from Internet Explorer|
+|chrome|Integer|Number of clicks from Chrome|
+|firefox|Integer|Number of clicks from Firefox|
+|safari|Integer|Number of clicks from Safari|
+|other|Integer|Number of clicks from browsers not listed|


### PR DESCRIPTION
**References**: [ANALYTICS-4807](https://jira.gannett.com/browse/ANALYTICS-4807)

**Code PR**: https://github.com/GannettDigital/reach-analytics-reporting-service/pull/1794

**Description**:
Support the scenario where a single MCID might have more than one Site Impact campaign associated it with it.

Create a new version of the API so that Client Center can continue to use the original endpoint.
