### PR TITLE
EDGE-9045 | data_subtyping_in_lips

### DIFF
--- a/source/includes/_lips_contact_interactions.md
+++ b/source/includes/_lips_contact_interactions.md
@@ -52,6 +52,9 @@ chat_service | ChatEvents with a lead_type of service. Ignored when used in com
 chat_other | ChatEvents with a lead type of other. Ignored when used in combination with `chat`
 form | FormEvents with a sub_type of FormPost
 email | FormEvents with a sub_type of FormEmail
+dyipost | FormEvents with a sub_type of DIYFORMPOST
+facebook | FormEvents with a sub_type of Facebook
+promotion | FormEvents with a sub_type of Promotion
 fpd | All FpdEvents
 
 ### Examples:

--- a/source/includes/_lips_contact_interactions_totals.md
+++ b/source/includes/_lips_contact_interactions_totals.md
@@ -43,6 +43,9 @@ chat_service | ChatEvents with a lead_type of service. Ignored when used in com
 chat_other | ChatEvents with a lead type of other. Ignored when used in combination with `chat`
 form | FormEvents with a sub_type of FormPost
 email | FormEvents with a sub_type of FormEmail
+dyipost | FormEvents with a sub_type of DIYFORMPOST
+facebook | FormEvents with a sub_type of Facebook
+promotion | FormEvents with a sub_type of Promotion
 fpd | All FpdEvents
 
 ### Examples:


### PR DESCRIPTION
**References**: [EDGE-9045](https://jira.gannett.com/browse/EDGE-9045)

**Code PR**: https://github.com/GannettDigital/lead-ingestion-publication-service/pull/289

**Description**:
We need to add a dyipost, facebook and promotion as sub types in lips.