### PR TITLE
EDGE-8303 Add target_phone

### DIFF
--- a/source/includes/_lips_contact_interactions.md
+++ b/source/includes/_lips_contact_interactions.md
@@ -169,10 +169,15 @@ curl -L -g -X GET 'https://data-connect-lips.ganettdigital.com/contact_interacti
 
 **Call**
 
+only included when interaction is call
+
 | Field Name | Datatype | Nullable | Description |
 |---|---|---|---|
-|call_recording_url| String | yes | Only included when interaction is call|
-|call_duration| Integer | yes | Length of call in seconds -- only included when interaction is call|
+|call_recording_url| String | yes | Call recording URL.  Use this to access the call recording. |
+|call_duration| Integer | yes | Length of call in seconds |
+|target_number| String | yes | In instances where a client has phone replacement tracking provisioned, the target_phone value is the phone number that was displayed on the client website. |
+|caller_number| String | yes | The caller's phone number |
+|dialed_number| String | yes | The dialed phone number |
 
 **Booking**
 


### PR DESCRIPTION
**References**: [EDGE-8303](https://jira.gannett.com/browse/EDGE-8303)
**Code PR**: https://github.com/GannettDigital/lead-ingestion-publication-service/pull/291

**Description**:
The **target_phone** field is part of the Call Event data provided by Capture. In instances where a client has phone replacement tracking provisioned in Capture the target_phone value is the phone number that was displayed on the  client website (final number called in a phone replacement flow).

In the contact interactions API include the field of target_phone in the Call event response data.

A call to the Contact Interactions API with a GMAID that has Call Events tracked (phone replacement provisioned) will include the **target_phone** field and value in the Call events data as part of the response data.

**Testing Instructions**:
With demo data loaded

```
curl --location --globoff 'http://localhost:3000/events?event_type[]=call&global_master_advertiser_id=TEST_1' \
--header 'Authorization: TOKEN'
```