### PR TITLE
Update _socialads_campaign_metrics.md.erb

### DIFF
--- a/source/includes/_socialads_campaign_metrics.md.erb
+++ b/source/includes/_socialads_campaign_metrics.md.erb
@@ -849,6 +849,7 @@ https://api.localiqservices.com/client_reports/facebook_campaign/TEST_1?start_da
 |omni_purchase_actions|Int|No| Purchases Value for Interval |
 |omni_purchase_purchase_roas|Int|No| Purchase ROAS for Interval |
 |omni_purchase_action_values|Int|No| Purchase Conversion Value for Interval |
+|leads|Int|No|Total Leads for Interval|
 |cpc|Int|No|Total Cost per Click for Interval|
 |cpm|Int|No|Total Cost per Milli for Interval|
 |ctr|Int|No|Total Click Through Rate for Interval|
@@ -859,6 +860,7 @@ https://api.localiqservices.com/client_reports/facebook_campaign/TEST_1?start_da
 
 |Field Name|Datatype|Nullable|Description|
 |---|---|---|---|
+|leads|Int|No|Total Leads|
 |impressions|Int|No|Total Impressions|
 |call_to_action_clicks|Int|No|Total Call to Action Clicks|
 |clicks|Int|No|Total Clicks|


### PR DESCRIPTION
The documentation response examples showed "leads" for intervals, totals and interval totals but this value was not reflected in the description of the API response.   Added the Leads item to the API response description.

**References**: [EDGE-0000](https://jira.gannett.com/browse/EDGE-0000)

**Code PR**: https://github.com/GannettDigital/

**Description**:
A few sentences describing the overall goals of the pull request's commits.